### PR TITLE
Add Initial operator + tests (steps 1–6)

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/operators/__init__.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/__init__.py
@@ -1,5 +1,6 @@
 """Initializing all the existing anonymizers."""
 
+
 from .operator import OperatorType, Operator  # isort:skip
 from .aes_cipher import AESCipher
 from .custom import Custom
@@ -12,6 +13,7 @@ from .keep import Keep
 from .mask import Mask
 from .redact import Redact
 from .replace import Replace
+from .initial import Initial
 
 try:
     from .ahds_surrogate import AHDSSurrogate
@@ -37,6 +39,7 @@ __all__ = [
     "AESCipher",
     "OperatorsFactory",
     "AHDS_AVAILABLE",
+    "Initial",
 ]
 
 if AHDS_AVAILABLE:

--- a/presidio-anonymizer/presidio_anonymizer/operators/initial.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/initial.py
@@ -1,0 +1,47 @@
+import re
+from typing import Dict
+from presidio_anonymizer.operators import Operator, OperatorType
+
+
+class Initial(Operator):
+    """Operator that converts names or multi-word phrases to initials."""
+
+    def operate(self, text: str = None, params: Dict = None) -> str:
+        # If no text provided, nothing to do
+        if not text:
+            return text
+
+        # Trim external whitespace
+        stripped = text.strip()
+        if stripped == "":
+            return ""
+
+        # Find prefix of all characters BEFORE the first alphanumeric
+        match = re.search(r"[A-Za-z0-9]", stripped)
+        if not match:
+            # No alphanumeric characters at all
+            return stripped
+
+        prefix = stripped[:match.start()]     # Things like @ -- ** etc.
+        rest = stripped[match.start():]       # Where words begin
+
+        # Split rest into words
+        words = rest.split()
+
+        initials = []
+        for word in words:
+            m = re.search(r"[A-Za-z0-9]", word)
+            if m:
+                initials.append(f"{m.group(0).upper()}.")
+
+        return prefix + " ".join(initials)
+
+    def validate(self, params: Dict = None) -> None:
+        """This operator takes no parameters."""
+        return
+
+    def operator_name(self) -> str:
+        return "initial"
+
+    def operator_type(self) -> OperatorType:
+        return OperatorType.Anonymize

--- a/presidio-anonymizer/presidio_anonymizer/operators/operators_factory.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/operators_factory.py
@@ -16,12 +16,15 @@ from presidio_anonymizer.operators import (
     OperatorType,
     Redact,
     Replace,
+    Initial, 
 )
 
 logger = logging.getLogger("presidio-anonymizer")
 
 # Predefined operators
-ANONYMIZERS = [Custom, Encrypt, Hash, Keep, Mask, Redact, Replace]
+from presidio_anonymizer.operators.initial import Initial
+ANONYMIZERS = [Custom, Encrypt, Hash, Keep, Mask, Redact, Replace, Initial]
+
 if AHDS_AVAILABLE and AHDSSurrogate:
     ANONYMIZERS.append(AHDSSurrogate)
 

--- a/presidio-anonymizer/tests/operators/test_initial.py
+++ b/presidio-anonymizer/tests/operators/test_initial.py
@@ -1,0 +1,31 @@
+import pytest
+
+from presidio_anonymizer.operators.initial import Initial
+
+
+def test_correct_name():
+    assert Initial().operator_name() == "initial"
+
+
+@pytest.mark.parametrize(
+    "input_text, initials",
+    [
+        ("John Smith", "J. S."),
+        ("     Eastern    Michigan   University ", "E. M. U."),
+    ],
+)
+def test_given_value_for_initial(input_text, initials):
+    text = Initial().operate(input_text)
+    assert text == initials
+    
+    @pytest.mark.parametrize(
+    "input_text, expected",
+    [
+        ("@abc", "@A."),
+        ("@843A", "@8."),
+        ("--**abc", "--**A."),
+    ],
+)
+    def test_leading_non_alphanumeric_is_preserved(input_text, expected):
+        text = Initial().operate(input_text)
+        assert text == expected

--- a/presidio-anonymizer/tests/test_anonymizer_engine.py
+++ b/presidio-anonymizer/tests/test_anonymizer_engine.py
@@ -17,7 +17,7 @@ from presidio_anonymizer.operators import OperatorType, AHDS_AVAILABLE
 
 def test_given_request_anonymizers_return_list():
     engine = AnonymizerEngine()
-    expected_list = {"hash", "mask", "redact", "replace", "custom", "keep", "encrypt"}
+    expected_list = {"hash", "mask", "redact", "replace", "custom", "keep", "encrypt", "initial"}
     if AHDS_AVAILABLE:
         expected_list.add("surrogate_ahds")
     anon_list = set(engine.get_anonymizers())


### PR DESCRIPTION
Implements the new `initial` anonymizer operator and basic tests.

- Adds `Initial` operator class
- Registers it in `OperatorsFactory`
- Updates `test_anonymizer_engine` to include `"initial"`
- Adds `tests/operators/test_initial.py`:
  - operator_name is `"initial"`
  - "John Smith" → "J. S."
  - Trims extra whitespace and preserves leading non-alphanumeric characters

Related to: #1
